### PR TITLE
[wip] Add RTD new config file

### DIFF
--- a/.github/workflows/trigger_rtd.yml
+++ b/.github/workflows/trigger_rtd.yml
@@ -2,12 +2,20 @@ name: RTD
 
 # Controls when the action will run. Triggers the workflow on push request, or repository dispatch
 on:
+  # Runs when pushing to 'latest'branch
   push:
     branches: [latest]
+    
+  # Run in every PR too
   pull_request:
+  
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
     
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
+
   # This workflow contains a single job called "build"
   build:
     #  The type of runner that the job will run on
@@ -15,6 +23,7 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the jobs
     steps:
+    
       # Trigger RTD build
       - name: Build the docs
         run: |

--- a/.github/workflows/trigger_rtd.yml
+++ b/.github/workflows/trigger_rtd.yml
@@ -1,9 +1,10 @@
-name: Netlify
+name: RTD
 
 # Controls when the action will run. Triggers the workflow on push request, or repository dispatch
 on:
   push:
     branches: [latest]
+  pull_request:
     
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/trigger_rtd.yml
+++ b/.github/workflows/trigger_rtd.yml
@@ -1,0 +1,23 @@
+name: Netlify
+
+# Controls when the action will run. Triggers the workflow on push request, or repository dispatch
+on:
+  push:
+    branches: [latest]
+    
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    #  The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the jobs
+    steps:
+      # Trigger RTD build
+      - name: Build the docs
+        run: |
+          curl -X POST -H "Authorization: Token ${{ secrets.TOKEN_RTD }}" \
+          https://readthedocs.org/api/v3/projects/dachs-doc/versions/latest/builds/
+        # env:
+        #   TOKEN_RTD: ${{ secrets.TOKEN_RTD }}

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+
+# We recommend specifying your dependencies to enable reproducible builds:
+# https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#   - requirements: docs/requirements.txt

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
 
 # We recommend specifying your dependencies to enable reproducible builds:
 # https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html

--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.11"
+    python: "3.8"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
ReadTheDocs now uses a config file `.readthedocs.yaml` to set the docs pipeline.
The job/pipeline starts fine but was crashing, apparently around `Element hdf5Grammar`.
See rtd error: https://readthedocs.org/projects/dachs-doc/builds/22316821/ .